### PR TITLE
Fix poster generator HTML syntax

### DIFF
--- a/index.html
+++ b/index.html
@@ -1012,7 +1012,7 @@
                                     <div class="text-xs text-gray-300">L'AVOCAT / JUGE IMPROMPTUS</div>
                                 </div>
                                  <div class="text-center">
-                                    <div class="character-icon chatgpt mx-auto mb-2" style="width: 70px; height: 70px;"> testemunha  testemunha</div>
+                                    <div class="character-icon chatgpt mx-auto mb-2" style="width: 70px; height: 70px;"> 🍋</div>
                                     <div class="text-sm text-green-400 font-bold">CHATGPT</div>
                                     <div class="text-xs text-gray-300">LE TÉMOIN</div>
                                 </div>
@@ -1423,7 +1423,7 @@
             ${canvas.innerHTML}
         </div>
     </div>
-<script type="module" src="/index.tsx"></script>
+<script type="module" src="/index.tsx"><\/script>
 </body>
 </html>`;
             


### PR DESCRIPTION
## Summary
- replace stray text with lemon emoji for ChatGPT witness card
- escape closing script tag in generated HTML string

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_684a766b86b08324b6569dcc66eb4a28